### PR TITLE
Fixed issue with FF and changed directive name from `hotTable` to `ha…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,8 @@
 {
   "name": "ngHandsontable",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "dependencies": {
-    "angular": "~1.3.15",
+    "angular": "~1.4.1",
     "handsontable": "~0.14.1"
   },
   "homepage": "https://github.com/handsontable/ngHandsontable",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/handsontable/ngHandsontable"
   },
   "author": "Marcin Warpechowski <hello@handsontable.com>",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "devDependencies": {
     "grunt": "~0.4.5",
     "grunt-contrib-uglify": "~0.5.1",

--- a/src/directives/ngHandsontable.js
+++ b/src/directives/ngHandsontable.js
@@ -3,7 +3,7 @@ angular.module('ngHandsontable.directives', [])
  * Main Angular Handsontable directive
  */
 	.directive(
-	'hotTable',
+	'handsOnTable',
 	[
 		'settingFactory',
 		'autoCompleteFactory',
@@ -126,7 +126,7 @@ angular.module('ngHandsontable.directives', [])
 		function () {
 			return {
 				restrict: 'E',
-				require:'^hotTable',
+				require:'^handsOnTable',
 				scope:{},
 				controller:['$scope', function ($scope) {
 					this.setColumnOptionList = function (options) {


### PR DESCRIPTION
Fixed issue with FF and changed directive name from `hotTable` to `handsOnTable`
It's a quite drastic change, but it's the only way to prevent to handsontable to use the Polymer element integrated in the library
